### PR TITLE
Add simple CLI help and docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +689,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "cmake"
 version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +736,12 @@ checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "const-oid"
@@ -1204,6 +1300,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,6 +1573,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,6 +1785,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "askama",
+ "clap",
  "rand_core 0.6.4",
  "rusqlite",
  "russh",
@@ -1773,6 +1882,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "opaque-debug"
@@ -2555,6 +2670,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2781,6 +2902,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ serde_yaml = "0.9"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time", "net"] }
 russh = "0.53"
 rand_core = "0.6"
+clap = { version = "4", features = ["derive"] }

--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ cargo build --release
 
 The resulting binary can be found at `target/release/nojs-chat` and does not require any runtime dependencies.
 
-Configuration is read from `config.yml`. A sample file is provided as `config.example.yml`.
+Configuration is read from `config.yml` by default. A sample file is provided as `config.example.yml`.
 
 ## Docker
 
@@ -23,3 +23,21 @@ docker compose up --build
 The generated onion address will be written to `tor-data/hostname` after the first start.
 
 When running the binary directly, the chat is available over both HTTP and SSH. Adjust the ports and chat name through `config.yml`.
+
+## Usage
+
+After building, run the server with:
+
+```bash
+./target/release/nojs-chat [OPTIONS]
+```
+
+Command line flags allow overriding values from the configuration file:
+
+- `-p`, `--port <PORT>` – HTTP port (defaults to `config.yml` or 8080)
+- `-s`, `--ssh <PORT>` – SSH port (defaults to `config.yml` or 2222)
+- `-n`, `--name <NAME>` – chat name
+- `-c`, `--config <FILE>` – path to the configuration file
+- `-h`, `--help` – show all flags
+
+Upon start, the binary prints which ports it is listening on and the chosen chat name.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use actix_web::cookie::{time::Duration, Cookie};
 use actix_web::{web, App, HttpRequest, HttpResponse, HttpServer, Responder};
 use askama::Template;
+use clap::Parser;
 use rusqlite::{params, Connection};
 use russh::server::{Auth, Msg, Server as _, Session};
 use russh::{server, Channel, ChannelId, CryptoVec};
@@ -26,6 +27,26 @@ impl Default for Config {
             chat_name: "NoJS Chat".to_string(),
         }
     }
+}
+
+#[derive(Parser)]
+#[command(name = "nojs-chat", about = "Minimal chat server over HTTP and SSH")]
+struct Args {
+    /// HTTP port
+    #[arg(short = 'p', long = "port")]
+    http_port: Option<u16>,
+
+    /// SSH port
+    #[arg(short = 's', long = "ssh")]
+    ssh_port: Option<u16>,
+
+    /// Chat name
+    #[arg(short = 'n', long = "name")]
+    chat_name: Option<String>,
+
+    /// Path to config file
+    #[arg(short = 'c', long = "config", default_value = "config.yml")]
+    config: String,
 }
 
 struct AppState {
@@ -61,7 +82,7 @@ struct SshServer {
 impl SshServer {
     async fn broadcast(&self, msg: &str) {
         let mut clients = self.clients.lock().await;
-        let data = CryptoVec::from(format!("{}\r\n", msg));
+        let data = CryptoVec::from(format!("\r\n{}\r\n> ", msg));
         for (_, (_, channel, handle)) in clients.iter_mut() {
             let _ = handle.data(*channel, data.clone()).await;
         }
@@ -122,6 +143,13 @@ impl server::Handler for SshServer {
             );
         }
 
+        // Simple TUI welcome screen
+        session.data(channel.id(), CryptoVec::from("\x1b[2J\x1b[H"))?;
+        if let Some(name) = &self.username {
+            let welcome = format!("Welcome, {}! Type /help for commands.\r\n", name);
+            session.data(channel.id(), CryptoVec::from(welcome))?;
+        }
+
         // Send chat history
         if let Some(name) = &self.username {
             let history = {
@@ -150,6 +178,7 @@ impl server::Handler for SshServer {
 
             let join_msg = format!("* {} joined", name);
             self.broadcast(&join_msg).await;
+            session.data(channel.id(), CryptoVec::from("> "))?;
         }
         Ok(true)
     }
@@ -166,6 +195,18 @@ impl server::Handler for SshServer {
         let msg = String::from_utf8_lossy(data).trim().to_string();
         if msg.is_empty() {
             return Ok(());
+        }
+        if msg == "/help" {
+            let help = "Commands:\n/help - this help\n/quit - exit chat\n";
+            let clients = self.clients.lock().await;
+            if let Some((_, channel, handle)) = clients.get(&self.id) {
+                let _ = handle.data(*channel, CryptoVec::from(help)).await;
+                let _ = handle.data(*channel, CryptoVec::from("> ")).await;
+            }
+            return Ok(());
+        }
+        if msg == "/quit" {
+            return Err(russh::Error::Disconnect);
         }
         if let Some(name) = &self.username {
             {
@@ -192,6 +233,14 @@ impl server::Handler for SshServer {
         session: &mut Session,
     ) -> Result<(), Self::Error> {
         session.close(channel)?;
+        {
+            let mut clients = self.clients.lock().await;
+            clients.remove(&self.id);
+        }
+        if let Some(name) = &self.username {
+            let leave = format!("* {} left", name);
+            self.broadcast(&leave).await;
+        }
         Ok(())
     }
 }
@@ -216,10 +265,27 @@ struct MessageForm {
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let config: Config = std::fs::read_to_string("config.yml")
+    let args = Args::parse();
+
+    let mut config: Config = std::fs::read_to_string(&args.config)
         .ok()
         .and_then(|c| serde_yaml::from_str(&c).ok())
         .unwrap_or_default();
+
+    if let Some(p) = args.http_port {
+        config.http_port = p;
+    }
+    if let Some(p) = args.ssh_port {
+        config.ssh_port = p;
+    }
+    if let Some(n) = args.chat_name {
+        config.chat_name = n;
+    }
+
+    println!(
+        "Starting {} on http port {} and ssh port {}",
+        config.chat_name, config.http_port, config.ssh_port
+    );
 
     let conn = Connection::open("chat.db").expect("open db");
     conn.execute(


### PR DESCRIPTION
## Summary
- add `clap` and implement basic CLI argument handling
- print startup message with chosen ports and chat name
- document how to build and run the server with command line options

## Testing
- `cargo check`
- `cargo test -- --list`